### PR TITLE
Fix local build (remove git safe.directory)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ghcr.io/samvera/hyku/base:latest as hyku-web
 ARG APP_PATH
 COPY --chown=1001:101 $APP_PATH/Gemfile* /app/samvera/hyrax-webapp/
-RUN git config --global --add safe.directory /app/samvera && \
-  bundle install --jobs "$(nproc)"
+RUN bundle install --jobs "$(nproc)"
 
 COPY --chown=1001:101 $APP_PATH/bin/db-migrate-seed.sh /app/samvera/
 # This is specifically NOT $APP_PATH but the parent directory


### PR DESCRIPTION
# Story

Allows building docker image locally to succeed by removing the git `safe.directory` config. 

**I'm not sure if this change should be committed, but it's what allowed me to spin the project up successfully.** 

Specs: 

- 2021 MacBook Pro M1 
  - MacOS Ventura 13.6 
  - Docker Desktop v4.24.0 

# Expected Behavior Before Changes

Running `docker compose build web worker` fails 

# Expected Behavior After Changes

Running `docker compose build web worker` succeeds 