### PR TITLE
:bug: [i12] add symlink to public/branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
 COPY --chown=1001:101 . /app/samvera
 ENV BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
 ENV BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
+RUN ln -sf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding
 
 FROM hyku-knap-base as hyku-web
 RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install


### PR DESCRIPTION
This commit is required to resolve the issue with uploading images from the Collections' branding tab. Because the symlink wasn't established, a user would not be able to see the images they uploaded even though the path correctly exists.

Issue:
- https://github.com/scientist-softserv/hykuup_knapsack/issues/12

Related PR:
- https://github.com/scientist-softserv/atla-hyku/pull/187

BEFORE

![image](https://github.com/scientist-softserv/hykuup_knapsack/assets/10081604/6018e0a0-925b-4c27-a298-4b96db925dbf)



AFTER

(we need to deploy this to get a screenshot)