### PR TITLE
Working knapsacked bundler-inject setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera
-COPY --chown=1001:101 Gemfile_override.rb /app/.bundler.d/
+COPY --chown=1001:101 bundler.d/ /app/.bundler.d/
 ENV BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
 ENV BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera
+COPY --chown=1001:101 Gemfile_override.rb /app/.bundler.d/
 ENV BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
 ENV BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
+
+RUN bundle install --jobs "$(nproc)"
 
 # Ensure root permissions for installing Tesseract data
 USER root

--- a/Gemfile_override.rb
+++ b/Gemfile_override.rb
@@ -1,0 +1,18 @@
+# rubocop:disable Naming/FileName
+# frozen_string_literal: true
+
+# See https://github.com/ManageIQ/bundler-inject
+#
+# The gems listed in this file are injected into bundler.
+# - `gem` to add new gems
+# - `override_gem` to change an existing gem (e.g. the version)
+# - `ensure_gem` to make sure a gem is there w/o worrying about if it is an override or not
+#
+# The bundler-inject plugin is enabled in Hyku's Gemfile (1). This file gets copied
+# into /app/.bundler.d/ within Docker (2), where it is then automatically loaded by the plugin (3).
+# (1) See hyrax-webapp/Gemfile
+# (2) See Dockerfile
+# (3) See https://github.com/ManageIQ/bundler-inject/blob/2fd8e3c62e49fbd1113fd3008a28e8fc0465e906/lib/bundler/inject/dsl_patch.rb#L92-L96
+
+override_gem 'bulkrax', '5.4.1'
+# rubocop:enable Naming/FileName

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -1,6 +1,0 @@
-# see https://github.com/kbrock/bundler-inject/tree/gem_path
-
-# specify one or more ruby files in this directory to be injected into bundler
-# you can use `gem` to add new gems, `override_gem` to change an existing gem
-# or `ensure_gem` to make sure a gem is there w/o worrying about if it is an
-# override or not

--- a/bundler.d/injected_gems.rb
+++ b/bundler.d/injected_gems.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Naming/FileName
 # frozen_string_literal: true
 
 # See https://github.com/ManageIQ/bundler-inject
@@ -15,4 +14,3 @@
 # (3) See https://github.com/ManageIQ/bundler-inject/blob/2fd8e3c62e49fbd1113fd3008a28e8fc0465e906/lib/bundler/inject/dsl_patch.rb#L92-L96
 
 override_gem 'bulkrax', '5.4.1'
-# rubocop:enable Naming/FileName


### PR DESCRIPTION
# Story

Working knapsacked bundler-inject setup plus Bulkrax bug fix (Importer form). 

# Expected Behavior Before Changes

The importer form throws an error. 

# Expected Behavior After Changes

Gems listed in `bundler.d/injected_gems.rb` are injected into bundler. 

The importer form doesn't throw an error. 

# Notes

HykuUP Knapsack's implementation technically works differently than Hyku's; Hyku will load all files in the `bundler.d/` dir automatically and considers these "local" gems. HykuUP Knapsack, on the other hand, copies files in the `bundler.d/` dir into the Docker image's `/app/.bundler.d/` dir, which gets loaded as "global" gems.

The main reason for this difference is due to all the file loading differences between Hyku and a knapsack'ed Hyku. The true app is nested within `hyrax-webapp/`, which the plugin doesn't look at.