### PR TITLE
Mobius Bulkrax field mappings

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -2,30 +2,33 @@
 
 # Ensure Knapsack version gets loaded after Hyku's bulkrax.rb
 Rails.application.config.after_initialize do
+  # OVERRIDE Bulkrax v5.4.1
+  # Override default split regex to only split on unescaped comma and pipe chars
+  Bulkrax.instance_variable_set(:@multi_value_element_split_on, /\s*(?<!\\)[,|]\s*/)
+
   Bulkrax.setup do |config|
     hyku_csv_field_mappings = config.field_mappings['Bulkrax::CsvParser']
 
     config.field_mappings['Bulkrax::CsvParser'] = hyku_csv_field_mappings.merge({
-      # FIXME: these split configs don't fully work as intended
-      'contributor' => { from: %w[sm_contributor contributor], split: /\s*(?<!\\)[,|]\s*/ },
-      'creator' => { from: %w[sm_creator creator], split: /\s*(?<!\\)[,|]\s*/ },
-      'date_created' => { from: %w[sm_date date_created], split: /\s*(?<!\\)[,|]\s*/ },
-      'description' => { from: %w[tm_description description], split: /\s*(?<!\\)[,|]\s*/ },
-      'identifier' => { from: %w[ss_pid identifier], split: /\s*(?<!\\)[,|]\s*/, source_identifier: true },
-      'language' => { from: %w[sm_language language], split: /\s*(?<!\\)[,|]\s*/ },
-      'parents' => { from: %w[sm_collection parents], split: /\s*(?<!\\)[,|]\s*/, related_parents_field_mapping: true },
-      'publisher' => { from: %w[sm_publisher publisher], split: /\s*(?<!\\)[,|]\s*/ },
-      'resource_type' => { from: %w[sm_type resource_type], split: /\s*(?<!\\)[,|]\s*/ },
-      'source' => { from: %w[sm_source source], split: /\s*(?<!\\)[,|]\s*/ },
-      'subject' => { from: %w[sm_subject subject], split: /\s*(?<!\\)[,|]\s*/ },
-      'title' => { from: %w[sm_title title], split: /\s*(?<!\\)[,|]\s*/ },
+      'contributor' => { from: %w[sm_contributor contributor], split: true },
+      'creator' => { from: %w[sm_creator creator], split: true },
+      'date_created' => { from: %w[sm_date date_created], split: true },
+      'description' => { from: %w[tm_description description], split: true },
+      'identifier' => { from: %w[ss_pid identifier], split: true, source_identifier: true },
+      'language' => { from: %w[sm_language language], split: true },
+      'parents' => { from: %w[sm_collection parents], split: true, related_parents_field_mapping: true },
+      'publisher' => { from: %w[sm_publisher publisher], split: true },
+      'resource_type' => { from: %w[sm_type resource_type], split: true },
+      'source' => { from: %w[sm_source source], split: true },
+      'subject' => { from: %w[sm_subject subject], split: true },
+      'title' => { from: %w[sm_title title], split: true },
       # Custom property mappings
-      'collection' => { from: %w[bs_iscollection collection], split: /\s*(?<!\\)[,|]\s*/ },
-      'community' => { from: %w[bs_iscommunity community], split: /\s*(?<!\\)[,|]\s*/ },
-      'coverage' => { from: %w[sm_coverage coverage], split: /\s*(?<!\\)[,|]\s*/ },
-      'file_format' => { from: %w[sm_format file_format], split: /\s*(?<!\\)[,|]\s*/ },
-      'relation' => { from: %w[sm_relation relation], split: /\s*(?<!\\)[,|]\s*/ },
-      'rights' => { from: %w[sm_rights rights], split: /\s*(?<!\\)[,|]\s*/ }
+      'collection' => { from: %w[bs_iscollection collection], split: true },
+      'community' => { from: %w[bs_iscommunity community], split: true },
+      'coverage' => { from: %w[sm_coverage coverage], split: true },
+      'file_format' => { from: %w[sm_format file_format], split: true },
+      'relation' => { from: %w[sm_relation relation], split: true },
+      'rights' => { from: %w[sm_rights rights], split: true }
     })
   end
 end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Ensure Knapsack version gets loaded after Hyku's bulkrax.rb
+Rails.application.config.after_initialize do
+  Bulkrax.setup do |config|
+    hyku_csv_field_mappings = config.field_mappings['Bulkrax::CsvParser']
+
+    config.field_mappings['Bulkrax::CsvParser'] = hyku_csv_field_mappings.merge({
+      # FIXME: these split configs don't fully work as intended
+      'contributor' => { from: %w[sm_contributor contributor], split: /\s*(?<!\\),\s*/ },
+      'creator' => { from: %w[sm_creator creator], split: /\s*(?<!\\),\s*/ },
+      'date_created' => { from: %w[sm_date date_created], split: /\s*(?<!\\),\s*/ },
+      'description' => { from: %w[tm_description description], split: /\s*(?<!\\),\s*/ },
+      'identifier' => { from: %w[ss_pid identifier], split: /\s*(?<!\\),\s*/, source_identifier: true },
+      'language' => { from: %w[sm_language language], split: /\s*(?<!\\),\s*/ },
+      'parents' => { from: %w[sm_collection parents], split: /\s*(?<!\\),\s*/, related_parents_field_mapping: true },
+      'publisher' => { from: %w[sm_publisher publisher], split: /\s*(?<!\\),\s*/ },
+      'resource_type' => { from: %w[sm_type resource_type], split: /\s*(?<!\\),\s*/ },
+      'source' => { from: %w[sm_source source], split: /\s*(?<!\\),\s*/ },
+      'subject' => { from: %w[sm_subject subject], split: /\s*(?<!\\),\s*/ },
+      'title' => { from: %w[sm_title title], split: /\s*(?<!\\),\s*/ },
+      # Custom property mappings
+      'collection' => { from: %w[bs_iscollection collection], split: /\s*(?<!\\),\s*/ },
+      'community' => { from: %w[bs_iscommunity community], split: /\s*(?<!\\),\s*/ },
+      'coverage' => { from: %w[sm_coverage coverage], split: /\s*(?<!\\),\s*/ },
+      'file_format' => { from: %w[sm_format file_format], split: /\s*(?<!\\),\s*/ },
+      'relation' => { from: %w[sm_relation relation], split: /\s*(?<!\\),\s*/ },
+      'rights' => { from: %w[sm_rights rights], split: /\s*(?<!\\),\s*/ }
+    })
+  end
+end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -7,25 +7,25 @@ Rails.application.config.after_initialize do
 
     config.field_mappings['Bulkrax::CsvParser'] = hyku_csv_field_mappings.merge({
       # FIXME: these split configs don't fully work as intended
-      'contributor' => { from: %w[sm_contributor contributor], split: /\s*(?<!\\),\s*/ },
-      'creator' => { from: %w[sm_creator creator], split: /\s*(?<!\\),\s*/ },
-      'date_created' => { from: %w[sm_date date_created], split: /\s*(?<!\\),\s*/ },
-      'description' => { from: %w[tm_description description], split: /\s*(?<!\\),\s*/ },
-      'identifier' => { from: %w[ss_pid identifier], split: /\s*(?<!\\),\s*/, source_identifier: true },
-      'language' => { from: %w[sm_language language], split: /\s*(?<!\\),\s*/ },
-      'parents' => { from: %w[sm_collection parents], split: /\s*(?<!\\),\s*/, related_parents_field_mapping: true },
-      'publisher' => { from: %w[sm_publisher publisher], split: /\s*(?<!\\),\s*/ },
-      'resource_type' => { from: %w[sm_type resource_type], split: /\s*(?<!\\),\s*/ },
-      'source' => { from: %w[sm_source source], split: /\s*(?<!\\),\s*/ },
-      'subject' => { from: %w[sm_subject subject], split: /\s*(?<!\\),\s*/ },
-      'title' => { from: %w[sm_title title], split: /\s*(?<!\\),\s*/ },
+      'contributor' => { from: %w[sm_contributor contributor], split: /\s*(?<!\\)[,|]\s*/ },
+      'creator' => { from: %w[sm_creator creator], split: /\s*(?<!\\)[,|]\s*/ },
+      'date_created' => { from: %w[sm_date date_created], split: /\s*(?<!\\)[,|]\s*/ },
+      'description' => { from: %w[tm_description description], split: /\s*(?<!\\)[,|]\s*/ },
+      'identifier' => { from: %w[ss_pid identifier], split: /\s*(?<!\\)[,|]\s*/, source_identifier: true },
+      'language' => { from: %w[sm_language language], split: /\s*(?<!\\)[,|]\s*/ },
+      'parents' => { from: %w[sm_collection parents], split: /\s*(?<!\\)[,|]\s*/, related_parents_field_mapping: true },
+      'publisher' => { from: %w[sm_publisher publisher], split: /\s*(?<!\\)[,|]\s*/ },
+      'resource_type' => { from: %w[sm_type resource_type], split: /\s*(?<!\\)[,|]\s*/ },
+      'source' => { from: %w[sm_source source], split: /\s*(?<!\\)[,|]\s*/ },
+      'subject' => { from: %w[sm_subject subject], split: /\s*(?<!\\)[,|]\s*/ },
+      'title' => { from: %w[sm_title title], split: /\s*(?<!\\)[,|]\s*/ },
       # Custom property mappings
-      'collection' => { from: %w[bs_iscollection collection], split: /\s*(?<!\\),\s*/ },
-      'community' => { from: %w[bs_iscommunity community], split: /\s*(?<!\\),\s*/ },
-      'coverage' => { from: %w[sm_coverage coverage], split: /\s*(?<!\\),\s*/ },
-      'file_format' => { from: %w[sm_format file_format], split: /\s*(?<!\\),\s*/ },
-      'relation' => { from: %w[sm_relation relation], split: /\s*(?<!\\),\s*/ },
-      'rights' => { from: %w[sm_rights rights], split: /\s*(?<!\\),\s*/ }
+      'collection' => { from: %w[bs_iscollection collection], split: /\s*(?<!\\)[,|]\s*/ },
+      'community' => { from: %w[bs_iscommunity community], split: /\s*(?<!\\)[,|]\s*/ },
+      'coverage' => { from: %w[sm_coverage coverage], split: /\s*(?<!\\)[,|]\s*/ },
+      'file_format' => { from: %w[sm_format file_format], split: /\s*(?<!\\)[,|]\s*/ },
+      'relation' => { from: %w[sm_relation relation], split: /\s*(?<!\\)[,|]\s*/ },
+      'rights' => { from: %w[sm_rights rights], split: /\s*(?<!\\)[,|]\s*/ }
     })
   end
 end


### PR DESCRIPTION
# Story

Ref
- #165 

Adds [Mobius' field mappings](https://docs.google.com/spreadsheets/d/12quM0rKmv6g0Dm83dDKcaKkrnz8lyjxMShAMSVg3Hec/edit#gid=0).  

# Screenshots / Video

<details>
<summary>Screenshot</summary>

![Show Entry Hyku 2024-03-11 at 5 12 17 PM](https://github.com/scientist-softserv/hykuup_knapsack/assets/32469930/de433316-5e9b-42e7-aa91-cfb2592d4035)

</details>

# Notes

While `\,` is not split on (as intended), it does result in unwanted characters in the data: 

- Input: `hello\, world` 
- Desired output: `["hello, world"]` 
- Actual output: `["hello\\, world"]` 

This issue should be fixed, but is not solvable in the field mapping config and is thus out of scope of this PR. 

See [this related Slack thread](https://assaydepot.slack.com/archives/C0313NK5NMA/p1710202020519149) :thread: 