### PR TITLE
Update base image of dockerfile for Hyku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/samvera/hyku:i35-latest as hyku-knap-base
+FROM ghcr.io/samvera/hyku/base:valkyrie as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
+FROM ghcr.io/samvera/hyku:valkyrie-3fbf2f40 as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/samvera/hyku:valkyrie-3fbf2f40 as hyku-knap-base
+FROM ghcr.io/samvera/hyku:i35-latest as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera


### PR DESCRIPTION
This PR is based off of [this one. ](https://github.com/scientist-softserv/hykuup_knapsack/pull/174)

The only real change here is to the dockerfile.

point to ghcr.io/samvera/hyku:valkyrie-3fbf2f40 - the hyku image built with all of the updates of i35-valkyrize-hyku

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes