### PR TITLE
⚙️ Move gems to bundler.d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/samvera/hyku/base:latest as hyku-knap-base
 
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera
+COPY --chown=1001:101 bundler.d/ /app/.bundler.d/
 ENV BUNDLE_LOCAL__HYKU_KNAPSACK=/app/samvera
 ENV BUNDLE_DISABLE_LOCAL_BRANCH_CHECK=true
 

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -5,3 +5,7 @@
 # you can use `gem` to add new gems, `override_gem` to change an existing gem
 # or `ensure_gem` to make sure a gem is there w/o worrying about if it is an
 # override or not
+
+gem "sentry-ruby"
+gem "sentry-rails"
+gem "sentry-sidekiq"

--- a/hyku_knapsack.gemspec
+++ b/hyku_knapsack.gemspec
@@ -25,7 +25,4 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 5.2.0"
-  spec.add_dependency "sentry-ruby"
-  spec.add_dependency "sentry-rails"
-  spec.add_dependency "sentry-sidekiq"
 end


### PR DESCRIPTION
Prior to this the gems were part of the gemspec which meant Hyku prime updated to include those sentry gems as dependencies.